### PR TITLE
add removed-in parameter to deprecated_params inspired by the old deprecation library

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,8 @@ repos:
   rev: v1.17.0
   hooks:
   -   id: mypy
+      additional_dependencies:
+      - pytest
       args: [--ignore-missing-imports, --strict]
 - repo: https://github.com/codespell-project/codespell
   rev: v2.2.6

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -14,6 +14,18 @@ def test_deprecated_param() -> None:
         my_func(0, x=0)
 
 
+def test_deprecated_param_removed_in() -> None:
+    @deprecated_params(["x"], "is deprecated", removed_in={"x": (0, 1, 5)})
+    def my_func(w: int, *, x: int = 0, y: int = 0) -> None:
+        pass
+
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Parameter \"x\" is deprecated \[Removed In\: 0.1.5\]",
+    ):
+        my_func(0, x=0)
+
+
 def test_class_wrapper_and_kw_display_disabled() -> None:
     @deprecated_params(["foo"], "foo is deprecated", display_kw=False)
     class MyClass:
@@ -33,7 +45,7 @@ class TornadoWarning(DeprecationWarning):
     pass
 
 
-@pytest.mark.skipif(sys.version_info < (3, 10), reason="kw_only not on 3.9")  # type: ignore[misc]
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="kw_only not on 3.9")
 def test_dataclasses_with_wrapper_message_dicts_custom_warning() -> None:
     from dataclasses import dataclass, field
 


### PR DESCRIPTION
I was a little bit inspired by the old deprecation library to make some adjustments for users who would like to know what version a keyword value might be removed in to aid in readability of warnings. I also added sphinx formatted doc-strings to the `__init__` function as we may want to look into adding a readthedocs page in the future based on the recent 3,000 downloads of this library.