### PR TITLE
Enable automatic upgrades

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.4
+  rev: v0.15.12
   hooks:
     - id: ruff-check
     - id: ruff-format

--- a/deprecated_params/__init__.py
+++ b/deprecated_params/__init__.py
@@ -133,9 +133,7 @@ class FinalMeta(type):
         for b in bases:
             if isinstance(b, FinalMeta):
                 raise TypeError(
-                    "type '{0}' cannot be subclassed further".format(
-                        b.__name__
-                    )
+                    f"type '{b.__name__}' cannot be subclassed further"
                 )
         return type.__new__(cls, name, bases, dict(classdict), **kwds)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ select = [
     "E",
     "W",
     "I",
-    "F"
-]
-ignore = [
-    "F405" # may be undefined, or defined from star imports (I Need these)
+    "F",
+    "UP",
 ]

--- a/tests/test_wrapper.py
+++ b/tests/test_wrapper.py
@@ -1,6 +1,5 @@
 import sys
 import warnings
-from typing import Optional
 
 import pytest
 
@@ -82,7 +81,7 @@ def test_deprecated_param_repeat_twice() -> None:
 def test_class_wrapper_and_kw_display_disabled() -> None:
     @deprecated_params(["foo"], "foo is deprecated", display_kw=False)
     class MyClass:
-        def __init__(self, spam: str, *, foo: Optional[str] = None):
+        def __init__(self, spam: str, *, foo: str | None = None):
             self.spam = spam
             self.foo = foo
 
@@ -97,7 +96,7 @@ def test_class_wrapper_and_kw_display_disabled() -> None:
 def test_class_wrapper_and_kw_display_disabled_one_param() -> None:
     @deprecated_params("foo", "foo is deprecated", display_kw=False)
     class MyClass:
-        def __init__(self, spam: str, *, foo: Optional[str] = None):
+        def __init__(self, spam: str, *, foo: str | None = None):
             self.spam = spam
             self.foo = foo
 
@@ -126,8 +125,8 @@ def test_dataclasses_with_wrapper_message_dicts_custom_warning() -> None:
     )
     @dataclass
     class Class:
-        foo: Optional[str] = field(kw_only=True, default=None)
-        spam: Optional[str] = field(kw_only=True, default=None)
+        foo: str | None = field(kw_only=True, default=None)
+        spam: str | None = field(kw_only=True, default=None)
 
     with pytest.warns(TornadoWarning, match="got foo"):
         Class(foo="foo")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes allow ruff to automatically update the code to newer python syntaxes when older versions of python are dropped or no longer in use.

## Are there changes in behavior for the user?

`Optional` keywords should be removed now as support for 3.9 should've been dropped by around now...

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist
<!-- These Are important the more you check off and actually perform the 
higher the chance your pull request succeeds. -->

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
